### PR TITLE
chore: update ref for ark-crypto-primitives dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,7 @@ members = [
     "common",
 ]
 
-default-members = [
-    "bitvm",
-    "bridge",
-    "fuzz",
-    "common",
-]
+default-members = ["bitvm", "bridge", "fuzz", "common"]
 
 [workspace.dependencies]
 bitcoin-script = { git = "https://github.com/BitVM/rust-bitcoin-script" }
@@ -28,7 +23,10 @@ hex = "0.4.3"
 bitcoin-scriptexec = { git = "https://github.com/BitVM/rust-bitcoin-scriptexec" }
 serde = { version = "1.0.197", features = ["derive"] }
 num-traits = "0.2.18"
-ark-bn254 = { version = "0.5.0", features = ["curve", "scalar_field"], default-features = false }
+ark-bn254 = { version = "0.5.0", features = [
+    "curve",
+    "scalar_field",
+], default-features = false }
 ark-ff = "0.5.0"
 ark-ec = "0.5.0"
 ark-groth16 = "0.5.0"
@@ -58,16 +56,18 @@ colored = "2.0.0"
 itertools = "0.13.0"
 serde-big-array = "0.5.1"
 num-bigint = { version = "0.4.4", features = ["rand"] }
-ark-std = { version = "0.5.0", default-features = false, features = ["print-trace"] }
+ark-std = { version = "0.5.0", default-features = false, features = [
+    "print-trace",
+] }
 ark-crypto-primitives = { git = "https://github.com/arkworks-rs/crypto-primitives", tag = "v0.5.0", features = ["snark", "sponge"] }
 ark-relations = "0.5.0"
 serial_test = "*"
 tqdm = "0.7"
-secp256k1 = { version = "0.29.1", features = ["global-context"]}
+secp256k1 = { version = "0.29.1", features = ["global-context"] }
 derive_more = "2.0"
 bitvm-common = { path = "common" }
 tracing = "0.1.41"
-tracing-subscriber = { version = "0.3.19", features = ["env-filter"]}
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
 [profile.dev]
 opt-level = 3


### PR DESCRIPTION
This PR updates the `ark-crypto-primitives` dependency to use the `v0.5.0` tag instead of the `release-0.5.0` branch that has now been removed in upstream.